### PR TITLE
chore: add VSCode config and backend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "humao.rest-client"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "React: start",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": 3000
+    },
+    {
+      "name": "Python: FastAPI",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": ["app.main:app", "--reload"],
+      "cwd": "${workspaceFolder}/backend"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "javascript.validate.enable": false,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "eslint.enable": true,
+  "eslint.validate": ["typescript", "typescriptreact"],
+  "python.defaultInterpreterPath": "python",
+  "python.formatting.provider": "black",
+  "python.linting.enabled": true,
+  "python.linting.pylintEnabled": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "frontend: start",
+      "type": "npm",
+      "script": "start"
+    },
+    {
+      "label": "frontend: test",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "backend: uvicorn",
+      "type": "shell",
+      "command": "uvicorn app.main:app --reload",
+      "options": {
+        "cwd": "${workspaceFolder}/backend"
+      }
+    }
+  ]
+}

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Backend application package."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Confianet API")
+
+
+@app.get("/", tags=["health"])
+def read_root() -> dict[str, str]:
+    """Return service health message."""
+    return {"message": "Hello, World"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/tests/api.http
+++ b/tests/api.http
@@ -1,0 +1,7 @@
+@baseUrl = http://localhost:8000
+
+### Health check
+GET {{baseUrl}}/
+
+### Non-existent endpoint (should 404)
+GET {{baseUrl}}/does-not-exist


### PR DESCRIPTION
## Summary
- add VSCode settings, tasks, launch configs, and recommended extensions
- scaffold FastAPI backend with health endpoint and requirements
- document HTTP tests and ignore Python artifacts

## Testing
- `python -m py_compile backend/app/main.py`
- `npm test -- --watchAll=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6684137888332b1358b86538459d1