### PR TITLE
Fix TypeScript token extraction from stored session

### DIFF
--- a/src/helpers/api_helper.ts
+++ b/src/helpers/api_helper.ts
@@ -5,6 +5,7 @@ const { api } = config;
 
 interface AuthSession {
   access_token: string;
+  token?: string;
   token_type?: string;
   user?: unknown;
   [key: string]: unknown;
@@ -55,7 +56,19 @@ const clearAuthSession = (): void => {
 
 const getStoredAccessToken = (): string | null => {
   const session = loadAuthSession();
-  return session?.access_token ?? session?.token ?? null;
+  if (!session) {
+    return null;
+  }
+
+  if (typeof session.access_token === "string" && session.access_token.length > 0) {
+    return session.access_token;
+  }
+
+  if (typeof session.token === "string" && session.token.length > 0) {
+    return session.token;
+  }
+
+  return null;
 };
 
 const refreshClient = axios.create({ baseURL: api.API_URL, withCredentials: true });


### PR DESCRIPTION
## Summary
- add optional token property to stored auth session typing
- guard stored access token retrieval to only return string tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9c165f4d88332bfbd5fbc5aeee66d