### PR TITLE
feat(settings): enhance smtp tools and automation

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -24,6 +24,9 @@ class Settings(BaseSettings):
     invitation_ttl_seconds: int = 900  # 15 minutes by default
     # Key seed for encrypting MFA secrets and recovery codes (derive to 32 bytes)
     mfa_encrypt_seed: str = "dev-mfa-seed-change-me"
+    email_rate_limit_seconds: int = 300  # 5 minutes between correos por destinatario
+    email_idempotency_seconds: int = 900  # 15 minutos para considerar idempotente
+    webhook_timeout_seconds: int = 5
 
 
 

--- a/backend/app/repositories/email_logs.py
+++ b/backend/app/repositories/email_logs.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from typing import Optional
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from ..core.database import engine
+
+
+@dataclass
+class EmailSendLogEntry:
+    id: str
+    org_id: str
+    template_name: str
+    to_email: str
+    dedupe_hash: Optional[str]
+    sent_at: datetime
+
+
+def _row_to_entry(row: tuple[str, str, str, str, Optional[str], datetime]) -> EmailSendLogEntry:
+    return EmailSendLogEntry(
+        id=row[0],
+        org_id=row[1],
+        template_name=row[2],
+        to_email=row[3],
+        dedupe_hash=row[4],
+        sent_at=row[5],
+    )
+
+
+def ensure_table() -> None:
+    ddl = (
+        """
+        CREATE TABLE IF NOT EXISTS email_send_log (
+            id CHAR(36) NOT NULL,
+            org_id CHAR(36) NOT NULL,
+            template_name VARCHAR(128) NOT NULL,
+            to_email VARCHAR(254) NOT NULL,
+            dedupe_hash CHAR(64) NULL,
+            sent_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            INDEX idx_email_log_org_template (org_id, template_name, to_email, sent_at),
+            INDEX idx_email_log_dedupe (org_id, dedupe_hash)
+        )
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(text(ddl))
+
+
+def _hash(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def record_send(org_id: str, template_name: str, to_email: str, *, dedupe_key: Optional[str] = None, sent_at: Optional[datetime] = None) -> None:
+    ensure_table()
+    now = sent_at or datetime.utcnow()
+    dedupe_hash = _hash(dedupe_key) if dedupe_key else None
+    sql = text(
+        """
+        INSERT INTO email_send_log (id, org_id, template_name, to_email, dedupe_hash, sent_at)
+        VALUES (:id, :org_id, :template_name, :to_email, :dedupe_hash, :sent_at)
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(
+            sql,
+            {
+                "id": str(uuid4()),
+                "org_id": org_id,
+                "template_name": template_name,
+                "to_email": to_email,
+                "dedupe_hash": dedupe_hash,
+                "sent_at": now,
+            },
+        )
+
+
+def get_last_send(org_id: str, template_name: str, to_email: str) -> Optional[EmailSendLogEntry]:
+    ensure_table()
+    sql = text(
+        """
+        SELECT id, org_id, template_name, to_email, dedupe_hash, sent_at
+        FROM email_send_log
+        WHERE org_id = :org_id AND template_name = :template_name AND to_email = :to_email
+        ORDER BY sent_at DESC
+        LIMIT 1
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(
+            sql, {"org_id": org_id, "template_name": template_name, "to_email": to_email}
+        ).first()
+    if not row:
+        return None
+    return _row_to_entry(row)
+
+
+def get_last_by_dedupe(org_id: str, dedupe_key: str) -> Optional[EmailSendLogEntry]:
+    ensure_table()
+    dedupe_hash = _hash(dedupe_key)
+    sql = text(
+        """
+        SELECT id, org_id, template_name, to_email, dedupe_hash, sent_at
+        FROM email_send_log
+        WHERE org_id = :org_id AND dedupe_hash = :dedupe_hash
+        ORDER BY sent_at DESC
+        LIMIT 1
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(sql, {"org_id": org_id, "dedupe_hash": dedupe_hash}).first()
+    if not row:
+        return None
+    return _row_to_entry(row)

--- a/backend/app/repositories/invitation_tokens.py
+++ b/backend/app/repositories/invitation_tokens.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import text
+
+from ..core.crypto import decrypt_str, encrypt_str
+from ..core.database import engine
+
+
+def ensure_table() -> None:
+    ddl = (
+        """
+        CREATE TABLE IF NOT EXISTS invitation_tokens (
+            invitation_id CHAR(36) PRIMARY KEY,
+            token_enc TEXT NOT NULL,
+            created_at DATETIME NOT NULL
+        )
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(text(ddl))
+
+
+def store_token(invitation_id: str, raw_token: str) -> None:
+    ensure_table()
+    sql = text(
+        """
+        INSERT INTO invitation_tokens (invitation_id, token_enc, created_at)
+        VALUES (:invitation_id, :token_enc, :created_at)
+        ON DUPLICATE KEY UPDATE token_enc = VALUES(token_enc), created_at = VALUES(created_at)
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(
+            sql,
+            {
+                "invitation_id": invitation_id,
+                "token_enc": encrypt_str(raw_token),
+                "created_at": datetime.utcnow(),
+            },
+        )
+
+
+def get_token(invitation_id: str) -> Optional[str]:
+    ensure_table()
+    sql = text(
+        "SELECT token_enc FROM invitation_tokens WHERE invitation_id = :invitation_id LIMIT 1"
+    )
+    with engine.connect() as conn:
+        row = conn.execute(sql, {"invitation_id": invitation_id}).first()
+    if not row:
+        return None
+    try:
+        return decrypt_str(row[0])
+    except Exception:
+        return None
+
+
+def delete_token(invitation_id: str) -> None:
+    ensure_table()
+    sql = text("DELETE FROM invitation_tokens WHERE invitation_id = :invitation_id")
+    with engine.begin() as conn:
+        conn.execute(sql, {"invitation_id": invitation_id})

--- a/backend/app/repositories/invitations.py
+++ b/backend/app/repositories/invitations.py
@@ -1,30 +1,40 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from hashlib import sha256
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import select, desc
+from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
 from ..core.database import session_scope
 from ..core.settings import settings
 from ..models.invitation import UserInvitationORM
+from .invitation_tokens import delete_token, store_token
+
+
+@dataclass
+class InvitationToken:
+    token: str
+    invitation_id: str
+    expires_at: datetime
 
 
 def _hash(token: str) -> str:
     return sha256(token.encode("utf-8")).hexdigest()
 
 
-def create_invitation(org_id: str, invited_by: str, email: str, name: Optional[str], role: str) -> tuple[str, datetime]:
+def create_invitation(org_id: str, invited_by: str, email: str, name: Optional[str], role: str) -> InvitationToken:
     raw = str(uuid4())
     token_hash = _hash(raw)
     now = datetime.utcnow()
     expires = now + timedelta(seconds=settings.invitation_ttl_seconds)
+    invitation_id = str(uuid4())
     with session_scope() as session:  # type: Session
         inv = UserInvitationORM(
-            id=str(uuid4()),
+            id=invitation_id,
             org_id=org_id,
             email=email,
             name=name,
@@ -35,7 +45,8 @@ def create_invitation(org_id: str, invited_by: str, email: str, name: Optional[s
             expires_at=expires,
         )
         session.add(inv)
-    return raw, expires
+    store_token(invitation_id, raw)
+    return InvitationToken(token=raw, invitation_id=invitation_id, expires_at=expires)
 
 
 def get_invitation(token: str) -> Optional[UserInvitationORM]:
@@ -50,6 +61,7 @@ def mark_accepted(inv: UserInvitationORM) -> None:
         if obj:
             obj.accepted_at = datetime.utcnow()
             session.add(obj)
+    delete_token(inv.id)
 
 
 def get_latest_pending_invitation(org_id: str, email: str) -> Optional[UserInvitationORM]:

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
-from typing import Optional
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, HttpUrl, ValidationError
 
 from ..core.deps import require_roles
 from ..models.auth import MeResponse, Role
 from ..repositories.app_settings import get_json, set_json
+from ..core.emailer import SmtpConfig
+from ..core.settings import settings
+from ..services.email_delivery import EmailRateLimitError, send_templated_email
+from ..services.email_templates import EmailBranding, EmailTemplateManager
+from ..services.webhooks import DEFAULT_EVENTS, WebhookSettings, load_webhook_settings, save_webhook_settings
 
 
 router = APIRouter()
@@ -33,6 +39,75 @@ class EmailSettingsOut(BaseModel):
     use_ssl: bool
     from_name: str
     from_email: EmailStr
+
+
+class EmailTemplateOut(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    subject_template: str
+    body_html: str
+    allowed_variables: List[str]
+    sample_context: Dict[str, Any]
+    updated_at: Optional[datetime]
+
+
+class EmailTemplatesResponse(BaseModel):
+    branding: EmailBranding
+    templates: List[EmailTemplateOut]
+
+
+class EmailTemplateUpdatePayload(BaseModel):
+    subject_template: str = Field(min_length=3)
+    body_html: str = Field(min_length=3)
+
+
+class EmailTemplatePreviewPayload(BaseModel):
+    variables: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EmailTemplatePreviewResponse(BaseModel):
+    subject: str
+    html: str
+
+
+class EmailTestLogEntry(BaseModel):
+    level: str
+    message: str
+    timestamp: datetime
+
+
+class EmailTestPayload(BaseModel):
+    to_email: EmailStr
+    template_id: str = "user_invitation"
+    variables: Dict[str, Any] = Field(default_factory=dict)
+    smtp: Optional[EmailSettingsIn] = None
+
+
+class EmailTestResponse(BaseModel):
+    success: bool
+    idempotent: bool
+    detail: Optional[str]
+    logs: List[EmailTestLogEntry]
+
+
+class WebhookSettingsPayload(BaseModel):
+    url: Optional[str] = None
+    secret: Optional[str] = None
+    enabled_events: List[str] = Field(default_factory=lambda: list(DEFAULT_EVENTS))
+    enabled: bool = False
+
+
+class WebhookSettingsResponse(BaseModel):
+    url: Optional[HttpUrl] = None
+    secret: Optional[str] = None
+    enabled_events: List[str]
+    enabled: bool
+
+
+def _template_to_out(template: Any) -> EmailTemplateOut:
+    data = template.model_dump()
+    return EmailTemplateOut(**data)
 
 
 @router.get("/email", response_model=EmailSettingsOut)
@@ -83,3 +158,182 @@ def set_email_settings(payload: EmailSettingsIn, me: MeResponse = Depends(requir
         from_email=conf["from_email"],
     )
 
+
+@router.get("/email/templates", response_model=EmailTemplatesResponse)
+def list_email_templates(me: MeResponse = Depends(require_roles(Role.admin))) -> EmailTemplatesResponse:
+    manager = EmailTemplateManager(me.org_id)
+    templates = [_template_to_out(tpl) for tpl in manager.list_templates()]
+    return EmailTemplatesResponse(branding=manager.branding, templates=templates)
+
+
+@router.patch("/email/templates/branding", response_model=EmailBranding)
+def update_email_branding(payload: EmailBranding, me: MeResponse = Depends(require_roles(Role.admin))) -> EmailBranding:
+    manager = EmailTemplateManager(me.org_id)
+    branding = manager.save_branding(payload)
+    return branding
+
+
+@router.put("/email/templates/{template_id}", response_model=EmailTemplateOut)
+def update_email_template(
+    template_id: str,
+    payload: EmailTemplateUpdatePayload,
+    me: MeResponse = Depends(require_roles(Role.admin)),
+) -> EmailTemplateOut:
+    manager = EmailTemplateManager(me.org_id)
+    try:
+        updated = manager.save_template(template_id, subject_template=payload.subject_template, body_html=payload.body_html)
+    except KeyError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plantilla no encontrada")
+    return _template_to_out(updated)
+
+
+@router.post("/email/templates/{template_id}/preview", response_model=EmailTemplatePreviewResponse)
+def preview_email_template(
+    template_id: str,
+    payload: EmailTemplatePreviewPayload,
+    me: MeResponse = Depends(require_roles(Role.admin)),
+) -> EmailTemplatePreviewResponse:
+    manager = EmailTemplateManager(me.org_id)
+    try:
+        base_context = manager.sample_context(template_id)
+    except KeyError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plantilla no encontrada")
+    context = {**base_context, **payload.variables}
+    context.setdefault("organization_name", manager.branding.brand_name)
+    rendered = manager.render(template_id, context)
+    return EmailTemplatePreviewResponse(subject=rendered.subject, html=rendered.html)
+
+
+@router.post("/email/test", response_model=EmailTestResponse)
+def send_test_email(payload: EmailTestPayload, me: MeResponse = Depends(require_roles(Role.admin))) -> EmailTestResponse:
+    logs: List[EmailTestLogEntry] = []
+
+    def log(level: str, message: str) -> None:
+        logs.append(EmailTestLogEntry(level=level, message=message, timestamp=datetime.utcnow()))
+
+    manager = EmailTemplateManager(me.org_id)
+    try:
+        manager.get_template(payload.template_id)
+    except KeyError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plantilla no encontrada")
+
+    stored_conf = get_json(me.org_id, "email_settings") or {}
+    smtp_payload = payload.smtp
+    password: Optional[str] = None
+    if smtp_payload:
+        if smtp_payload.password is None:
+            password = stored_conf.get("password")
+        elif smtp_payload.password == "":
+            password = None
+        else:
+            password = smtp_payload.password
+        host = smtp_payload.smtp_host
+        port = smtp_payload.smtp_port
+        username = smtp_payload.username
+        use_tls = smtp_payload.use_tls
+        use_ssl = smtp_payload.use_ssl
+        from_name = smtp_payload.from_name
+        from_email = smtp_payload.from_email
+    else:
+        host = stored_conf.get("smtp_host")
+        port = int(stored_conf.get("smtp_port", 587)) if stored_conf else 587
+        username = stored_conf.get("username")
+        use_tls = bool(stored_conf.get("use_tls", True))
+        use_ssl = bool(stored_conf.get("use_ssl", False))
+        from_name = stored_conf.get("from_name", manager.branding.brand_name)
+        from_email = stored_conf.get("from_email")
+        password = stored_conf.get("password")
+
+    if not host or not from_email:
+        log("error", "Configura el servidor SMTP antes de enviar un correo de prueba")
+        return EmailTestResponse(success=False, idempotent=False, detail="Configuración SMTP incompleta", logs=logs)
+    if password is None or password == "":
+        log("error", "La contraseña SMTP es obligatoria para la prueba")
+        return EmailTestResponse(success=False, idempotent=False, detail="Contraseña SMTP requerida", logs=logs)
+
+    try:
+        smtp_cfg = SmtpConfig(
+            host=str(host),
+            port=int(port),
+            username=username,
+            password=password,
+            use_tls=bool(use_tls),
+            use_ssl=bool(use_ssl),
+            from_name=str(from_name or manager.branding.brand_name),
+            from_email=str(from_email),
+        )
+    except Exception as exc:
+        log("error", f"Configuración SMTP inválida: {exc}")
+        return EmailTestResponse(success=False, idempotent=False, detail="Configuración SMTP inválida", logs=logs)
+
+    log("info", f"Preparando prueba con plantilla {payload.template_id}")
+    context = manager.sample_context(payload.template_id)
+    context.update(payload.variables)
+    context.setdefault("organization_name", manager.branding.brand_name)
+    context.setdefault("invited_by_name", me.full_name or me.email)
+
+    try:
+        outcome = send_templated_email(
+            org_id=me.org_id,
+            template_id=payload.template_id,
+            smtp_cfg=smtp_cfg,
+            to_email=str(payload.to_email),
+            context=context,
+            dedupe_key=f"test:{payload.template_id}:{payload.to_email}",
+            rate_limit_seconds=max(60, settings.email_rate_limit_seconds // 2),
+            idempotency_window_seconds=settings.email_idempotency_seconds,
+        )
+    except EmailRateLimitError as exc:
+        log("error", f"Rate limit alcanzado. Intenta nuevamente en {exc.retry_after_seconds} segundos")
+        return EmailTestResponse(
+            success=False,
+            idempotent=False,
+            detail=f"Rate limit alcanzado. Intenta en {exc.retry_after_seconds} segundos",
+            logs=logs,
+        )
+    except Exception as exc:
+        log("error", f"Error enviando correo de prueba: {exc}")
+        return EmailTestResponse(success=False, idempotent=False, detail=f"Error enviando correo: {exc}", logs=logs)
+
+    if outcome.sent:
+        log("info", f"Correo de prueba enviado a {payload.to_email}")
+    elif outcome.idempotent:
+        log("info", "El correo ya se había enviado recientemente (idempotencia)")
+
+    return EmailTestResponse(
+        success=outcome.sent,
+        idempotent=outcome.idempotent,
+        detail=outcome.detail,
+        logs=logs,
+    )
+
+
+@router.get("/webhooks", response_model=WebhookSettingsResponse)
+def get_webhook_settings(me: MeResponse = Depends(require_roles(Role.admin))) -> WebhookSettingsResponse:
+    conf = load_webhook_settings(me.org_id)
+    return WebhookSettingsResponse(
+        url=conf.url,
+        secret=conf.secret,
+        enabled_events=conf.enabled_events,
+        enabled=conf.enabled,
+    )
+
+
+@router.put("/webhooks", response_model=WebhookSettingsResponse)
+def set_webhook_settings(
+    payload: WebhookSettingsPayload,
+    me: MeResponse = Depends(require_roles(Role.admin)),
+) -> WebhookSettingsResponse:
+    url_value = (payload.url or "").strip() or None
+    events = [event for event in payload.enabled_events if event in DEFAULT_EVENTS]
+    try:
+        conf = WebhookSettings(url=url_value, secret=payload.secret, enabled_events=events, enabled=payload.enabled and bool(url_value))
+    except ValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    saved = save_webhook_settings(me.org_id, conf)
+    return WebhookSettingsResponse(
+        url=saved.url,
+        secret=saved.secret,
+        enabled_events=saved.enabled_events,
+        enabled=saved.enabled,
+    )

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -11,7 +11,12 @@ from ..core.deps import require_roles
 from ..repositories.audit import log_event
 from ..core.settings import settings
 from ..models.auth import MeResponse, Role
-from ..repositories.invitations import create_invitation, get_invitation, mark_accepted, get_latest_pending_invitation
+from ..repositories.invitations import (
+    create_invitation,
+    get_invitation,
+    mark_accepted,
+    get_latest_pending_invitation,
+)
 from ..repositories.password_policy import get_policy, update_policy
 from ..core.security import hash_password, validate_password_policy
 from ..repositories.users import users_repo
@@ -25,10 +30,31 @@ import base64
 import json as _json
 import qrcode
 from ..repositories.app_settings import get_json
-from ..core.emailer import SmtpConfig, send_email
+from ..core.emailer import SmtpConfig
+from ..services.email_templates import EmailTemplateManager
+from ..services.email_delivery import EmailRateLimitError, send_templated_email
+from ..services.webhooks import trigger_webhook
+from ..repositories.invitation_tokens import get_token as get_invitation_token
 
 
 router = APIRouter()
+
+
+def _smtp_config_or_error(org_id: str) -> tuple[SmtpConfig, dict[str, Any]]:
+    conf = get_json(org_id, "email_settings")
+    if not conf or not conf.get("smtp_host") or not conf.get("from_email") or not conf.get("smtp_port"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email settings not configured")
+    smtp_cfg = SmtpConfig(
+        host=str(conf.get("smtp_host")),
+        port=int(conf.get("smtp_port", 587)),
+        username=conf.get("username"),
+        password=conf.get("password"),
+        use_tls=bool(conf.get("use_tls", True)),
+        use_ssl=bool(conf.get("use_ssl", False)),
+        from_name=str(conf.get("from_name", "Confianet")),
+        from_email=str(conf.get("from_email")),
+    )
+    return smtp_cfg, conf
 
 
 class InvitePayload(BaseModel):
@@ -40,7 +66,13 @@ class InvitePayload(BaseModel):
 
 @router.post("/invitations", status_code=status.HTTP_201_CREATED)
 def invite_user(payload: InvitePayload, request: Request, me: MeResponse = Depends(require_roles(Role.admin))) -> dict[str, Any]:
-    token, expires = create_invitation(org_id=me.org_id, invited_by=str(me.id), email=payload.email, name=payload.name, role=payload.role.value)
+    invitation = create_invitation(
+        org_id=me.org_id,
+        invited_by=str(me.id),
+        email=payload.email,
+        name=payload.name,
+        role=payload.role.value,
+    )
     # Ensure user exists in suspended (pending) state until password is set
     new_user_id: Optional[str] = None
     with session_scope() as session:
@@ -61,32 +93,37 @@ def invite_user(payload: InvitePayload, request: Request, me: MeResponse = Depen
             session.add(u)
             new_user_id = u.id
     # Build link for email
-    link = f"http://localhost:3000/auth-signup-basic?token={token}&email={payload.email}&name={payload.name or ''}"
+    link = f"http://localhost:3000/auth-signup-basic?token={invitation.token}&email={payload.email}&name={payload.name or ''}"
     # Send real email using org email settings
-    conf = get_json(me.org_id, "email_settings")
-    if not conf or not conf.get("smtp_host") or not conf.get("from_email") or not conf.get("smtp_port"):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email settings not configured")
-    smtp_cfg = SmtpConfig(
-        host=str(conf.get("smtp_host")),
-        port=int(conf.get("smtp_port", 587)),
-        username=conf.get("username"),
-        password=conf.get("password"),
-        use_tls=bool(conf.get("use_tls", True)),
-        use_ssl=bool(conf.get("use_ssl", False)),
-        from_name=str(conf.get("from_name", "Confianet")),
-        from_email=str(conf.get("from_email")),
-    )
-    subject = "Invitación a Confianet"
-    html = f"""
-    <p>Has sido invitado a unirte a Confianet{(' como ' + payload.role.value) if payload.role else ''}.</p>
-    <p>Haz clic en el siguiente enlace para crear tu contraseña:</p>
-    <p><a href="{link}">Completar registro</a></p>
-    <p>Si no solicitaste esta invitación, ignora este mensaje.</p>
-    """
+    smtp_cfg, conf = _smtp_config_or_error(me.org_id)
+    manager = EmailTemplateManager(me.org_id)
+    context = {
+        "invitee_name": payload.name or payload.email,
+        "organization_name": manager.branding.brand_name,
+        "invite_link": link,
+        "invited_by_name": me.full_name or me.email,
+        "expires_at": invitation.expires_at.isoformat(),
+    }
     try:
-        send_email(smtp_cfg, payload.email, subject, html)
+        outcome = send_templated_email(
+            org_id=me.org_id,
+            template_id="user_invitation",
+            smtp_cfg=smtp_cfg,
+            to_email=payload.email,
+            context=context,
+            dedupe_key=f"invitation:{invitation.invitation_id}",
+        )
+    except EmailRateLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Espera {exc.retry_after_seconds} segundos antes de reenviar otra invitación",
+        )
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"No se pudo enviar el correo: {e}")
+
+    if outcome.idempotent:
+        # No enviar respuesta de error; continuar para auditoría pero indicar en mensaje
+        pass
     # Audit: user invited
     client_ip = request.client.host if request.client else None
     target_id = new_user_id or (existing.id if existing else None)
@@ -101,7 +138,18 @@ def invite_user(payload: InvitePayload, request: Request, me: MeResponse = Depen
         ip=client_ip,
         ip_salt=settings.ip_hash_salt,
     )
-    return {"message": f"Invitación enviada a {payload.email}"}
+    trigger_webhook(
+        me.org_id,
+        "user.invited",
+        {
+            "email": payload.email,
+            "role": payload.role.value,
+            "invited_by": str(me.id),
+            "user_id": target_id,
+            "expires_at": invitation.expires_at.isoformat(),
+        },
+    )
+    return {"message": f"Invitación enviada a {payload.email}", "idempotent": outcome.idempotent}
 
 
 class AcceptInvitationPayload(BaseModel):
@@ -123,6 +171,7 @@ def accept_invitation(payload: AcceptInvitationPayload) -> Response:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg)
     pwd_hash = hash_password(payload.password)
     # Create or update user
+    activated_user_id: Optional[str] = None
     with session_scope() as session:
         existing = users_repo.get_by_email(inv.email)
         if existing:
@@ -131,6 +180,7 @@ def accept_invitation(payload: AcceptInvitationPayload) -> Response:
                 obj.password_hash = pwd_hash
                 obj.status = 'active'
                 session.add(obj)
+                activated_user_id = obj.id
         else:
             user = UserORM(
                 id=str(uuid4()),
@@ -144,7 +194,13 @@ def accept_invitation(payload: AcceptInvitationPayload) -> Response:
                 password_hash=pwd_hash,
             )
             session.add(user)
+            activated_user_id = user.id
     mark_accepted(inv)
+    trigger_webhook(
+        inv.org_id,
+        "user.activated",
+        {"email": inv.email, "user_id": activated_user_id},
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -256,6 +312,11 @@ def suspend_user(user_id: str, request: Request, me: MeResponse = Depends(requir
         metadata=None,
         ip=client_ip,
         ip_salt=settings.ip_hash_salt,
+    )
+    trigger_webhook(
+        me.org_id,
+        "user.suspended",
+        {"user_id": user_id, "by": str(me.id)},
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -393,30 +454,102 @@ def resend_invitation(user_id: str, request: Request, me: MeResponse = Depends(r
         role = obj.role
 
     # Check latest invitation status
-    from datetime import datetime
     latest = get_latest_pending_invitation(me.org_id, email)
-    if latest and latest.expires_at >= datetime.utcnow():
-        # We cannot reconstruct the raw token from its hash; indicate reuse.
-        # Audit reuse
-        client_ip = request.client.host if request.client else None
-        log_event(
-            action="invitation_reused",
-            org_id=me.org_id,
-            actor_id=str(me.id),
-            actor_role=me.role.value,
-            target_type="user",
-            target_id=user_id,
-            metadata={"expires_at": latest.expires_at.isoformat()},
-            ip=client_ip,
-            ip_salt=settings.ip_hash_salt,
-        )
-        return {"reused": True, "invitation_url": None, "expires_at": latest.expires_at.isoformat()}
+    manager = EmailTemplateManager(me.org_id)
+    smtp_cfg, _ = _smtp_config_or_error(me.org_id)
+    now = datetime.utcnow()
+    client_ip = request.client.host if request.client else None
+
+    if latest and latest.expires_at >= now:
+        token_raw = get_invitation_token(latest.id)
+        if not token_raw:
+            # Fall back to new invitation if token is not available
+            latest = None
+        else:
+            link = f"http://localhost:3000/auth-signup-basic?token={token_raw}&email={email}&name={name or ''}"
+            context = {
+                "invitee_name": name or email,
+                "organization_name": manager.branding.brand_name,
+                "invite_link": link,
+                "invited_by_name": me.full_name or me.email,
+                "expires_at": latest.expires_at.isoformat(),
+            }
+            try:
+                outcome = send_templated_email(
+                    org_id=me.org_id,
+                    template_id="user_invitation",
+                    smtp_cfg=smtp_cfg,
+                    to_email=email,
+                    context=context,
+                    dedupe_key=f"invitation:{latest.id}",
+                )
+            except EmailRateLimitError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=f"Espera {exc.retry_after_seconds} segundos antes de reenviar otra invitación",
+                )
+            except Exception as exc:
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"No se pudo reenviar el correo: {exc}")
+
+            action = "invitation_reused" if outcome.idempotent else "invitation_resent"
+            log_event(
+                action=action,
+                org_id=me.org_id,
+                actor_id=str(me.id),
+                actor_role=me.role.value,
+                target_type="user",
+                target_id=user_id,
+                metadata={"expires_at": latest.expires_at.isoformat(), "email": email},
+                ip=client_ip,
+                ip_salt=settings.ip_hash_salt,
+            )
+            trigger_webhook(
+                me.org_id,
+                "user.invited",
+                {
+                    "email": email,
+                    "role": role,
+                    "invited_by": str(me.id),
+                    "user_id": user_id,
+                    "expires_at": latest.expires_at.isoformat(),
+                    "resent": True,
+                    "idempotent": outcome.idempotent,
+                },
+            )
+            return {
+                "reused": True,
+                "invitation_url": link,
+                "expires_at": latest.expires_at.isoformat(),
+                "idempotent": outcome.idempotent,
+            }
 
     # Otherwise, create a new invitation
-    token, expires = create_invitation(org_id=me.org_id, invited_by=str(me.id), email=email, name=name, role=role)
-    link = f"http://localhost:3000/auth-signup-basic?token={token}&email={email}&name={name or ''}"
-    # Audit resend
-    client_ip = request.client.host if request.client else None
+    new_invitation = create_invitation(org_id=me.org_id, invited_by=str(me.id), email=email, name=name, role=role)
+    link = f"http://localhost:3000/auth-signup-basic?token={new_invitation.token}&email={email}&name={name or ''}"
+    context = {
+        "invitee_name": name or email,
+        "organization_name": manager.branding.brand_name,
+        "invite_link": link,
+        "invited_by_name": me.full_name or me.email,
+        "expires_at": new_invitation.expires_at.isoformat(),
+    }
+    try:
+        outcome = send_templated_email(
+            org_id=me.org_id,
+            template_id="user_invitation",
+            smtp_cfg=smtp_cfg,
+            to_email=email,
+            context=context,
+            dedupe_key=f"invitation:{new_invitation.invitation_id}",
+        )
+    except EmailRateLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Espera {exc.retry_after_seconds} segundos antes de reenviar otra invitación",
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"No se pudo reenviar el correo: {exc}")
+
     log_event(
         action="invitation_resent",
         org_id=me.org_id,
@@ -428,7 +561,25 @@ def resend_invitation(user_id: str, request: Request, me: MeResponse = Depends(r
         ip=client_ip,
         ip_salt=settings.ip_hash_salt,
     )
-    return {"reused": False, "invitation_url": link, "expires_at": expires.isoformat()}
+    trigger_webhook(
+        me.org_id,
+        "user.invited",
+        {
+            "email": email,
+            "role": role,
+            "invited_by": str(me.id),
+            "user_id": user_id,
+            "expires_at": new_invitation.expires_at.isoformat(),
+            "resent": False,
+            "idempotent": outcome.idempotent,
+        },
+    )
+    return {
+        "reused": False,
+        "invitation_url": link,
+        "expires_at": new_invitation.expires_at.isoformat(),
+        "idempotent": outcome.idempotent,
+    }
 
 class PasswordPolicyPayload(BaseModel):
     min_length: int = 10

--- a/backend/app/services/email_delivery.py
+++ b/backend/app/services/email_delivery.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ..core.emailer import SmtpConfig, send_email
+from ..core.settings import settings
+from ..repositories.email_logs import get_last_by_dedupe, get_last_send, record_send
+from .email_templates import EmailTemplateManager
+
+
+@dataclass
+class EmailSendOutcome:
+    sent: bool
+    idempotent: bool
+    subject: Optional[str] = None
+    html: Optional[str] = None
+    last_sent_at: Optional[datetime] = None
+    detail: Optional[str] = None
+
+
+class EmailRateLimitError(Exception):
+    def __init__(self, retry_after_seconds: int, last_sent_at: datetime) -> None:
+        super().__init__("Rate limit reached")
+        self.retry_after_seconds = retry_after_seconds
+        self.last_sent_at = last_sent_at
+
+
+
+def send_templated_email(
+    org_id: str,
+    template_id: str,
+    smtp_cfg: SmtpConfig,
+    to_email: str,
+    context: Dict[str, Any],
+    *,
+    dedupe_key: Optional[str] = None,
+    rate_limit_seconds: Optional[int] = None,
+    idempotency_window_seconds: Optional[int] = None,
+) -> EmailSendOutcome:
+    now = datetime.utcnow()
+    rate_limit_seconds = rate_limit_seconds or settings.email_rate_limit_seconds
+    idempotency_window_seconds = idempotency_window_seconds or settings.email_idempotency_seconds
+
+    if dedupe_key:
+        existing = get_last_by_dedupe(org_id, dedupe_key)
+        if existing and (now - existing.sent_at).total_seconds() < idempotency_window_seconds:
+            return EmailSendOutcome(
+                sent=False,
+                idempotent=True,
+                last_sent_at=existing.sent_at,
+                detail="Idempotent: el mensaje ya se envió recientemente",
+            )
+
+    last = get_last_send(org_id, template_id, to_email)
+    if last:
+        delta = (now - last.sent_at).total_seconds()
+        if delta < rate_limit_seconds:
+            raise EmailRateLimitError(int(rate_limit_seconds - delta), last.sent_at)
+
+    manager = EmailTemplateManager(org_id)
+    rendered = manager.render(template_id, context)
+    send_email(smtp_cfg, to_email, rendered.subject, rendered.html)
+    record_send(org_id, template_id, to_email, dedupe_key=dedupe_key, sent_at=now)
+    return EmailSendOutcome(
+        sent=True,
+        idempotent=False,
+        subject=rendered.subject,
+        html=rendered.html,
+        last_sent_at=now,
+    )

--- a/backend/app/services/email_templates.py
+++ b/backend/app/services/email_templates.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from jinja2 import BaseLoader, Environment, select_autoescape
+from markupsafe import Markup
+from pydantic import BaseModel, Field
+
+from ..repositories.app_settings import get_json, set_json
+
+
+class EmailBranding(BaseModel):
+    brand_name: str = "Confianet"
+    logo_url: Optional[str] = None
+    primary_color: str = "#1F2937"
+    button_text_color: str = "#FFFFFF"
+    footer_text: Optional[str] = None
+
+
+class EmailTemplateDefinition(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    subject_template: str
+    body_html: str
+    allowed_variables: List[str] = Field(default_factory=list)
+    sample_context: Dict[str, Any] = Field(default_factory=dict)
+    updated_at: Optional[datetime] = None
+
+
+@dataclass
+class RenderedEmail:
+    subject: str
+    html: str
+
+
+DEFAULT_BRANDING = EmailBranding()
+
+DEFAULT_LAYOUT = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>{{ subject }}</title>
+    <style>
+      body {
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        background-color: #f5f5f5;
+        color: #111827;
+        margin: 0;
+        padding: 24px;
+      }
+      .container {
+        max-width: 560px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+      }
+      .header {
+        background-color: {{ brand.primary_color }};
+        padding: 24px;
+        text-align: center;
+      }
+      .header img {
+        max-width: 180px;
+        height: auto;
+      }
+      .header h1 {
+        color: #ffffff;
+        margin: 0;
+        font-size: 24px;
+        font-weight: 600;
+      }
+      .content {
+        padding: 32px 32px 16px 32px;
+        line-height: 1.6;
+        color: #1f2937;
+      }
+      .content a.button {
+        display: inline-block;
+        background-color: {{ brand.primary_color }};
+        color: {{ brand.button_text_color }};
+        padding: 14px 22px;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 16px 0;
+      }
+      .footer {
+        padding: 16px 24px 32px 24px;
+        font-size: 12px;
+        color: #6b7280;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div class=\"container\">
+      <div class=\"header\">
+        {% if brand.logo_url %}
+          <img src=\"{{ brand.logo_url }}\" alt=\"{{ brand.brand_name }}\" />
+        {% else %}
+          <h1>{{ brand.brand_name }}</h1>
+        {% endif %}
+      </div>
+      <div class=\"content\">
+        {{ content | safe }}
+      </div>
+      {% if brand.footer_text %}
+        <div class=\"footer\">{{ brand.footer_text }}</div>
+      {% endif %}
+    </div>
+  </body>
+</html>
+"""
+
+
+DEFAULT_TEMPLATES: Dict[str, EmailTemplateDefinition] = {
+    "user_invitation": EmailTemplateDefinition(
+        id="user_invitation",
+        name="Invitación de usuario",
+        description="Correo que se envía cuando invitas a una persona a Confianet.",
+        subject_template="{{ organization_name }} te invitó a Confianet",
+        body_html="""
+<p>Hola {{ invitee_name or 'equipo' }},</p>
+<p>{{ invited_by_name }} te invitó a colaborar en <strong>{{ organization_name }}</strong>.</p>
+<p>Usa el siguiente botón para crear tu contraseña y activar tu cuenta:</p>
+<p><a class=\"button\" href=\"{{ invite_link }}\">Crear contraseña</a></p>
+<p>El enlace caduca el {{ expires_at }}.</p>
+<p>Si no esperabas este correo, puedes ignorarlo sin problemas.</p>
+""",
+        allowed_variables=[
+            "invitee_name",
+            "organization_name",
+            "invite_link",
+            "invited_by_name",
+            "expires_at",
+        ],
+        sample_context={
+            "invitee_name": "María López",
+            "organization_name": "Confianet Demo",
+            "invite_link": "https://demo.confianet.app/invitacion/123",
+            "invited_by_name": "Equipo Confianet",
+            "expires_at": "2024-12-31 23:59",
+        },
+    ),
+}
+
+
+class EmailTemplateManager:
+    STORAGE_KEY = "email_templates"
+
+    def __init__(self, org_id: str) -> None:
+        self.org_id = org_id
+        raw = get_json(org_id, self.STORAGE_KEY) or {}
+        branding_raw = raw.get("branding") or {}
+        templates_raw = raw.get("templates") or {}
+        # Merge branding with defaults
+        base_brand = DEFAULT_BRANDING.model_copy(deep=True)
+        for key, value in branding_raw.items():
+            if hasattr(base_brand, key) and value is not None:
+                setattr(base_brand, key, value)
+        self.branding = base_brand
+        self._templates_cache: Dict[str, EmailTemplateDefinition] = {}
+        self._templates_raw = templates_raw
+
+    def _merge_template(self, template_id: str) -> EmailTemplateDefinition:
+        default = DEFAULT_TEMPLATES[template_id]
+        stored = self._templates_raw.get(template_id) or {}
+        subject = stored.get("subject_template") or default.subject_template
+        body = stored.get("body_html") or default.body_html
+        updated_at: Optional[datetime] = None
+        if stored.get("updated_at"):
+            try:
+                updated_at = datetime.fromisoformat(stored["updated_at"])
+            except ValueError:
+                updated_at = None
+        return EmailTemplateDefinition(
+            id=default.id,
+            name=default.name,
+            description=default.description,
+            subject_template=subject,
+            body_html=body,
+            allowed_variables=list(default.allowed_variables),
+            sample_context=dict(default.sample_context),
+            updated_at=updated_at,
+        )
+
+    def list_templates(self) -> List[EmailTemplateDefinition]:
+        if not self._templates_cache:
+            for template_id in DEFAULT_TEMPLATES.keys():
+                self._templates_cache[template_id] = self._merge_template(template_id)
+        return list(self._templates_cache.values())
+
+    def get_template(self, template_id: str) -> EmailTemplateDefinition:
+        if template_id not in DEFAULT_TEMPLATES:
+            raise KeyError(f"Plantilla no soportada: {template_id}")
+        if template_id not in self._templates_cache:
+            self._templates_cache[template_id] = self._merge_template(template_id)
+        return self._templates_cache[template_id]
+
+    def save_template(self, template_id: str, *, subject_template: str, body_html: str) -> EmailTemplateDefinition:
+        if template_id not in DEFAULT_TEMPLATES:
+            raise KeyError(f"Plantilla no soportada: {template_id}")
+        now = datetime.utcnow().replace(microsecond=0)
+        self._templates_raw[template_id] = {
+            "subject_template": subject_template,
+            "body_html": body_html,
+            "updated_at": now.isoformat(),
+        }
+        payload = {
+            "branding": self.branding.model_dump(),
+            "templates": self._templates_raw,
+        }
+        set_json(self.org_id, self.STORAGE_KEY, payload)
+        self._templates_cache[template_id] = self._merge_template(template_id)
+        return self._templates_cache[template_id]
+
+    def save_branding(self, branding: EmailBranding) -> EmailBranding:
+        self.branding = branding
+        payload = {
+            "branding": branding.model_dump(),
+            "templates": self._templates_raw,
+        }
+        set_json(self.org_id, self.STORAGE_KEY, payload)
+        self._templates_cache.clear()
+        return branding
+
+    def render(self, template_id: str, context: Dict[str, Any]) -> RenderedEmail:
+        template = self.get_template(template_id)
+        env = Environment(loader=BaseLoader(), autoescape=select_autoescape(["html", "xml"]))
+        base_context = {**context, "brand": self.branding.model_dump()}
+        subject_template = env.from_string(template.subject_template)
+        subject = subject_template.render(**base_context)
+        body_template = env.from_string(template.body_html)
+        body_html = body_template.render(**base_context)
+        layout = env.from_string(DEFAULT_LAYOUT)
+        html = layout.render(subject=subject, brand=self.branding.model_dump(), content=Markup(body_html), **base_context)
+        return RenderedEmail(subject=subject, html=html)
+
+    def sample_context(self, template_id: str) -> Dict[str, Any]:
+        template = self.get_template(template_id)
+        return dict(template.sample_context)

--- a/backend/app/services/webhooks.py
+++ b/backend/app/services/webhooks.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import httpx
+from pydantic import BaseModel, Field, HttpUrl
+
+from ..core.settings import settings
+from ..repositories.app_settings import get_json, set_json
+
+logger = logging.getLogger("confianet.webhooks")
+
+
+class WebhookSettings(BaseModel):
+    url: Optional[HttpUrl] = None
+    secret: Optional[str] = None
+    enabled_events: list[str] = Field(default_factory=list)
+    enabled: bool = False
+
+
+DEFAULT_EVENTS = ["user.invited", "user.activated", "user.suspended"]
+STORAGE_KEY = "webhook_settings"
+
+
+def load_webhook_settings(org_id: str) -> WebhookSettings:
+    raw = get_json(org_id, STORAGE_KEY) or {}
+    data = {
+        "url": raw.get("url"),
+        "secret": raw.get("secret"),
+        "enabled_events": raw.get("enabled_events") or DEFAULT_EVENTS,
+        "enabled": bool(raw.get("enabled", False)),
+    }
+    try:
+        return WebhookSettings(**data)
+    except Exception:
+        return WebhookSettings(url=None, secret=None, enabled_events=DEFAULT_EVENTS, enabled=False)
+
+
+def save_webhook_settings(org_id: str, conf: WebhookSettings) -> WebhookSettings:
+    payload = {
+        "url": str(conf.url) if conf.url else None,
+        "secret": conf.secret,
+        "enabled_events": conf.enabled_events,
+        "enabled": conf.enabled,
+    }
+    set_json(org_id, STORAGE_KEY, payload)
+    return conf
+
+
+def trigger_webhook(org_id: str, event: str, data: Dict[str, Any]) -> None:
+    conf = load_webhook_settings(org_id)
+    if not conf.enabled:
+        return
+    if not conf.url:
+        return
+    if event not in conf.enabled_events:
+        return
+
+    body = {
+        "event": event,
+        "occurred_at": datetime.utcnow().isoformat() + "Z",
+        "data": data,
+    }
+    json_body = json.dumps(body)
+    headers = {
+        "User-Agent": "ConfianetWebhook/1.0",
+        "Content-Type": "application/json",
+    }
+    if conf.secret:
+        secret_bytes = conf.secret.encode("utf-8")
+        signature = hmac.new(secret_bytes, json_body.encode("utf-8"), hashlib.sha256).hexdigest()
+        headers["X-Confianet-Signature"] = signature
+
+    try:
+        with httpx.Client(timeout=settings.webhook_timeout_seconds) as client:
+            response = client.post(str(conf.url), data=json_body, headers=headers)
+            if response.status_code >= 400:
+                logger.warning("Webhook %s responded with %s", event, response.status_code)
+    except Exception as exc:  # pragma: no cover - network errors should not break flow
+        logger.warning("No se pudo enviar webhook %s: %s", event, exc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ SQLAlchemy>=2.0
 PyMySQL
 pyotp
 qrcode[pil]
+Jinja2
+httpx

--- a/src/pages/Admin/Settings.tsx
+++ b/src/pages/Admin/Settings.tsx
@@ -1,10 +1,49 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, Button, Card, CardBody, Col, Container, Form, Input, Label, Nav, NavItem, NavLink, Row, Spinner, TabContent, TabPane } from 'reactstrap';
+import { Alert, Badge, Button, Card, CardBody, CardHeader, Col, Container, Form, FormGroup, FormText, Input, Label, ListGroup, ListGroupItem, Nav, NavItem, NavLink, Row, Spinner, TabContent, TabPane } from 'reactstrap';
 import axios from 'axios';
 import { getLoggedinUser, setAuthorization } from '../../helpers/api_helper';
 
 type PasswordPolicy = { min_length: number; require_upper: boolean; require_number: boolean; require_symbol: boolean };
 type EmailSettings = { smtp_host: string; smtp_port: number; username?: string | null; has_password?: boolean; use_tls: boolean; use_ssl: boolean; from_name: string; from_email: string };
+
+type EmailTemplate = {
+  id: string;
+  name: string;
+  description?: string | null;
+  subject_template: string;
+  body_html: string;
+  allowed_variables: string[];
+  sample_context: Record<string, unknown>;
+  updated_at?: string | null;
+};
+
+type EmailBrandingState = {
+  brand_name: string;
+  logo_url?: string | null;
+  primary_color: string;
+  button_text_color: string;
+  footer_text?: string | null;
+};
+
+type EmailTemplatesResponse = {
+  branding: EmailBrandingState;
+  templates: EmailTemplate[];
+};
+
+type EmailTestLog = { level: string; message: string; timestamp: string };
+
+type EmailTestResult = { success: boolean; idempotent: boolean; detail?: string | null };
+
+type EmailTestResponse = EmailTestResult & { logs: EmailTestLog[] };
+
+type WebhookSettingsState = {
+  url?: string | null;
+  secret?: string | null;
+  enabled_events: string[];
+  enabled: boolean;
+};
+
+const AVAILABLE_WEBHOOK_EVENTS = ['user.invited', 'user.activated', 'user.suspended'];
 
 const AdminSettings: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'policy' | 'email'>('policy');
@@ -15,6 +54,21 @@ const AdminSettings: React.FC = () => {
   const [policy, setPolicy] = useState<PasswordPolicy>({ min_length: 12, require_upper: true, require_number: true, require_symbol: true });
   const [emailCfg, setEmailCfg] = useState<EmailSettings>({ smtp_host: '', smtp_port: 587, username: '', has_password: false, use_tls: true, use_ssl: false, from_name: 'Confianet', from_email: '' });
   const [emailPassword, setEmailPassword] = useState<string>('');
+  const [templates, setTemplates] = useState<EmailTemplate[]>([]);
+  const [branding, setBranding] = useState<EmailBrandingState>({ brand_name: 'Confianet', logo_url: '', primary_color: '#1F2937', button_text_color: '#FFFFFF', footer_text: '' });
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>('user_invitation');
+  const [templateSubject, setTemplateSubject] = useState<string>('');
+  const [templateBody, setTemplateBody] = useState<string>('');
+  const [templateSaving, setTemplateSaving] = useState(false);
+  const [brandingSaving, setBrandingSaving] = useState(false);
+  const [previewHtml, setPreviewHtml] = useState<string>('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [testEmail, setTestEmail] = useState<string>('');
+  const [testSending, setTestSending] = useState(false);
+  const [testLogs, setTestLogs] = useState<EmailTestLog[]>([]);
+  const [testResult, setTestResult] = useState<EmailTestResult | null>(null);
+  const [webhook, setWebhook] = useState<WebhookSettingsState>({ url: '', secret: '', enabled_events: [...AVAILABLE_WEBHOOK_EVENTS], enabled: false });
+  const [webhookSaving, setWebhookSaving] = useState(false);
 
   useEffect(() => {
     try {
@@ -29,6 +83,29 @@ const AdminSettings: React.FC = () => {
         setPolicy(pol as unknown as PasswordPolicy);
         const mail = await axios.get<EmailSettings>('/api/settings/email');
         setEmailCfg(mail as unknown as EmailSettings);
+        setTestEmail((mail as unknown as EmailSettings).from_email || '');
+        const tpl = await axios.get<EmailTemplatesResponse>('/api/settings/email/templates');
+        const templatesData = tpl as unknown as EmailTemplatesResponse;
+        setTemplates(templatesData.templates);
+        setBranding(templatesData.branding);
+        if (templatesData.templates.length > 0) {
+          const template = templatesData.templates.find(t => t.id === selectedTemplateId) || templatesData.templates[0];
+          setSelectedTemplateId(template.id);
+          setTemplateSubject(template.subject_template);
+          setTemplateBody(template.body_html);
+        } else {
+          setSelectedTemplateId('user_invitation');
+          setTemplateSubject('');
+          setTemplateBody('');
+        }
+        const webhookSettings = await axios.get<WebhookSettingsState & { url?: string | null; secret?: string | null }>('/api/settings/webhooks');
+        const whData = webhookSettings as unknown as WebhookSettingsState & { url?: string | null; secret?: string | null };
+        setWebhook({
+          url: whData.url ?? '',
+          secret: whData.secret ?? '',
+          enabled_events: whData.enabled_events?.length ? whData.enabled_events : [...AVAILABLE_WEBHOOK_EVENTS],
+          enabled: whData.enabled,
+        });
       } catch (e: any) {
         setError(e?.message || 'Error cargando configuración');
       } finally {
@@ -68,6 +145,142 @@ const AdminSettings: React.FC = () => {
       setMessage('Configuración de correo guardada');
     } catch (err: any) {
       setError(err?.message || 'No se pudo guardar el correo');
+    }
+  };
+
+  const activeTemplate = templates.find(t => t.id === selectedTemplateId) || null;
+
+  const handleTemplateSelect = (templateId: string) => {
+    setSelectedTemplateId(templateId);
+    const tpl = templates.find(t => t.id === templateId);
+    if (tpl) {
+      setTemplateSubject(tpl.subject_template);
+      setTemplateBody(tpl.body_html);
+    } else {
+      setTemplateSubject('');
+      setTemplateBody('');
+    }
+    setPreviewHtml('');
+  };
+
+  const handleTemplateSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedTemplateId) {
+      return;
+    }
+    setTemplateSaving(true);
+    setMessage(null); setError(null);
+    try {
+      const updated = await axios.put<EmailTemplate>(`/api/settings/email/templates/${selectedTemplateId}`, {
+        subject_template: templateSubject,
+        body_html: templateBody,
+      });
+      const tpl = updated as unknown as EmailTemplate;
+      setTemplates(prev => prev.map(item => (item.id === tpl.id ? tpl : item)));
+      setTemplateSubject(tpl.subject_template);
+      setTemplateBody(tpl.body_html);
+      setMessage('Plantilla actualizada');
+    } catch (err: any) {
+      setError(err?.message || 'No se pudo guardar la plantilla');
+    } finally {
+      setTemplateSaving(false);
+    }
+  };
+
+  const handlePreviewTemplate = async () => {
+    if (!selectedTemplateId) {
+      return;
+    }
+    setPreviewLoading(true);
+    setError(null);
+    try {
+      const preview = await axios.post<{ subject: string; html: string }>(`/api/settings/email/templates/${selectedTemplateId}/preview`, { variables: {} });
+      const data = preview as unknown as { subject: string; html: string };
+      setPreviewHtml(`<h4 style="margin-top:0">${data.subject}</h4>${data.html}`);
+    } catch (err: any) {
+      setError(err?.message || 'No se pudo generar la vista previa');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleBrandingSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setBrandingSaving(true);
+    setMessage(null); setError(null);
+    try {
+      const updated = await axios.patch<EmailBrandingState>('/api/settings/email/templates/branding', branding);
+      setBranding(updated as unknown as EmailBrandingState);
+      setMessage('Marca blanca actualizada');
+    } catch (err: any) {
+      setError(err?.message || 'No se pudo actualizar la marca');
+    } finally {
+      setBrandingSaving(false);
+    }
+  };
+
+  const handleSendTestEmail = async () => {
+    if (!testEmail) {
+      setError('Ingresa un correo de destino para la prueba');
+      return;
+    }
+    setTestSending(true);
+    setTestLogs([]);
+    setTestResult(null);
+    setMessage(null); setError(null);
+    try {
+      const response = await axios.post<EmailTestResponse>('/api/settings/email/test', {
+        to_email: testEmail,
+        template_id: selectedTemplateId,
+      });
+      const data = response as unknown as EmailTestResponse;
+      setTestLogs(data.logs || []);
+      setTestResult({ success: data.success, idempotent: data.idempotent, detail: data.detail });
+      if (data.success) {
+        setMessage('Correo de prueba enviado');
+      } else if (data.detail) {
+        setError(data.detail);
+      }
+    } catch (err: any) {
+      setError(err?.message || 'No se pudo enviar el correo de prueba');
+    } finally {
+      setTestSending(false);
+    }
+  };
+
+  const toggleWebhookEvent = (eventKey: string, checked: boolean) => {
+    setWebhook(prev => ({
+      ...prev,
+      enabled_events: checked
+        ? Array.from(new Set([...(prev.enabled_events || []), eventKey]))
+        : (prev.enabled_events || []).filter(item => item !== eventKey),
+    }));
+  };
+
+  const handleWebhookSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setWebhookSaving(true);
+    setMessage(null); setError(null);
+    try {
+      const payload = {
+        url: webhook.url?.trim() || null,
+        secret: webhook.secret?.trim() || null,
+        enabled_events: webhook.enabled_events,
+        enabled: webhook.enabled,
+      };
+      const saved = await axios.put<WebhookSettingsState & { url?: string | null; secret?: string | null }>('/api/settings/webhooks', payload);
+      const data = saved as unknown as WebhookSettingsState & { url?: string | null; secret?: string | null };
+      setWebhook({
+        url: data.url ?? '',
+        secret: data.secret ?? '',
+        enabled_events: data.enabled_events?.length ? data.enabled_events : [...AVAILABLE_WEBHOOK_EVENTS],
+        enabled: data.enabled,
+      });
+      setMessage('Webhook actualizado');
+    } catch (err: any) {
+      setError(err?.message || 'No se pudo guardar el webhook');
+    } finally {
+      setWebhookSaving(false);
     }
   };
 
@@ -111,21 +324,171 @@ const AdminSettings: React.FC = () => {
                 </CardBody></Card>
               </TabPane>
               <TabPane tabId="email">
-                <Card><CardBody>
-                  <Form onSubmit={saveEmail}>
-                    <Row className="g-3">
-                      <Col md={4}><Label>Servidor SMTP</Label><Input value={emailCfg.smtp_host} onChange={e => setEmailCfg({ ...emailCfg, smtp_host: e.target.value })} required /></Col>
-                      <Col md={2}><Label>Puerto</Label><Input type="number" value={emailCfg.smtp_port} onChange={e => setEmailCfg({ ...emailCfg, smtp_port: parseInt(e.target.value || '0', 10) })} required /></Col>
-                      <Col md={3}><Label>Usuario</Label><Input value={emailCfg.username || ''} onChange={e => setEmailCfg({ ...emailCfg, username: e.target.value })} /></Col>
-                      <Col md={3}><Label>Contraseña</Label><Input type="password" placeholder={emailCfg.has_password ? '••••••' : ''} value={emailPassword} onChange={e => setEmailPassword(e.target.value)} /></Col>
-                      <Col md={3}><Label>Remitente (nombre)</Label><Input value={emailCfg.from_name} onChange={e => setEmailCfg({ ...emailCfg, from_name: e.target.value })} required /></Col>
-                      <Col md={4}><Label>Remitente (email)</Label><Input type="email" value={emailCfg.from_email} onChange={e => setEmailCfg({ ...emailCfg, from_email: e.target.value })} required /></Col>
-                      <Col md={2}><div className="form-check mt-4"><Input className="form-check-input" type="checkbox" checked={emailCfg.use_tls} onChange={e => setEmailCfg({ ...emailCfg, use_tls: e.target.checked })} id="tls" /><Label className="form-check-label" htmlFor="tls">TLS</Label></div></Col>
-                      <Col md={2}><div className="form-check mt-4"><Input className="form-check-input" type="checkbox" checked={emailCfg.use_ssl} onChange={e => setEmailCfg({ ...emailCfg, use_ssl: e.target.checked })} id="ssl" /><Label className="form-check-label" htmlFor="ssl">SSL</Label></div></Col>
-                      <Col md={3} className="mt-4"><Button color="primary" type="submit">Guardar correo</Button></Col>
+                <Card>
+                  <CardBody>
+                    <Form onSubmit={saveEmail}>
+                      <Row className="g-3">
+                        <Col md={4}><Label>Servidor SMTP</Label><Input value={emailCfg.smtp_host} onChange={e => setEmailCfg({ ...emailCfg, smtp_host: e.target.value })} required /></Col>
+                        <Col md={2}><Label>Puerto</Label><Input type="number" value={emailCfg.smtp_port} onChange={e => setEmailCfg({ ...emailCfg, smtp_port: parseInt(e.target.value || '0', 10) })} required /></Col>
+                        <Col md={3}><Label>Usuario</Label><Input value={emailCfg.username || ''} onChange={e => setEmailCfg({ ...emailCfg, username: e.target.value })} /></Col>
+                        <Col md={3}><Label>Contraseña</Label><Input type="password" placeholder={emailCfg.has_password ? '••••••' : ''} value={emailPassword} onChange={e => setEmailPassword(e.target.value)} /></Col>
+                        <Col md={3}><Label>Remitente (nombre)</Label><Input value={emailCfg.from_name} onChange={e => setEmailCfg({ ...emailCfg, from_name: e.target.value })} required /></Col>
+                        <Col md={4}><Label>Remitente (email)</Label><Input type="email" value={emailCfg.from_email} onChange={e => setEmailCfg({ ...emailCfg, from_email: e.target.value })} required /></Col>
+                        <Col md={2}><div className="form-check mt-4"><Input className="form-check-input" type="checkbox" checked={emailCfg.use_tls} onChange={e => setEmailCfg({ ...emailCfg, use_tls: e.target.checked })} id="tls" /><Label className="form-check-label" htmlFor="tls">TLS</Label></div></Col>
+                        <Col md={2}><div className="form-check mt-4"><Input className="form-check-input" type="checkbox" checked={emailCfg.use_ssl} onChange={e => setEmailCfg({ ...emailCfg, use_ssl: e.target.checked })} id="ssl" /><Label className="form-check-label" htmlFor="ssl">SSL</Label></div></Col>
+                        <Col md={3} className="mt-4 d-flex align-items-end"><Button color="primary" type="submit">Guardar correo</Button></Col>
+                      </Row>
+                    </Form>
+                    <hr className="my-4" />
+                    <h6 className="mb-3">Enviar email de prueba</h6>
+                    <Row className="g-3 align-items-end">
+                      <Col md={4}><Label>Destinatario</Label><Input type="email" value={testEmail} onChange={e => setTestEmail(e.target.value)} placeholder="admin@tu-dominio.com" required /></Col>
+                      <Col md={4}>
+                        <Label>Plantilla</Label>
+                        <Input type="select" value={selectedTemplateId} onChange={e => handleTemplateSelect(e.target.value)}>
+                          {templates.length === 0 && <option value="user_invitation">user_invitation</option>}
+                          {templates.map(t => (
+                            <option key={t.id} value={t.id}>{t.name}</option>
+                          ))}
+                        </Input>
+                      </Col>
+                      <Col md={3} className="mt-3 mt-md-0">
+                        <Button color="secondary" type="button" onClick={handleSendTestEmail} disabled={testSending}>
+                          {testSending ? 'Enviando…' : 'Enviar email de prueba'}
+                        </Button>
+                      </Col>
                     </Row>
-                  </Form>
-                </CardBody></Card>
+                    {testResult && (
+                      <Alert color={testResult.success ? 'success' : 'warning'} className="mt-3">
+                        {testResult.success ? 'Correo de prueba enviado correctamente.' : testResult.detail || 'No se pudo enviar el correo.'}
+                        {testResult.idempotent && <div className="mt-1">Se utilizó el resultado más reciente (idempotente).</div>}
+                      </Alert>
+                    )}
+                    {testLogs.length > 0 && (
+                      <ListGroup className="mt-3">
+                        {testLogs.map((log, idx) => (
+                          <ListGroupItem key={`${log.timestamp}-${idx}`}>
+                            <Badge color={log.level === 'error' ? 'danger' : 'secondary'} className="me-2 text-uppercase">{log.level}</Badge>
+                            <small className="text-muted me-2">{new Date(log.timestamp).toLocaleString()}</small>
+                            {log.message}
+                          </ListGroupItem>
+                        ))}
+                      </ListGroup>
+                    )}
+                  </CardBody>
+                </Card>
+                <Card className="mt-4">
+                  <CardHeader><h5 className="mb-0">Gestor de plantillas</h5></CardHeader>
+                  <CardBody>
+                    {templates.length === 0 ? (
+                      <p className="text-muted mb-0">No hay plantillas configuradas.</p>
+                    ) : (
+                      <>
+                        <Row className="g-3">
+                          <Col md={4}>
+                            <FormGroup>
+                              <Label>Selecciona plantilla</Label>
+                              <Input type="select" value={selectedTemplateId} onChange={e => handleTemplateSelect(e.target.value)}>
+                                {templates.map(t => (
+                                  <option key={t.id} value={t.id}>{t.name}</option>
+                                ))}
+                              </Input>
+                            </FormGroup>
+                          </Col>
+                          <Col md={8} className="d-flex flex-column justify-content-center">
+                            <p className="mb-1 text-muted">{activeTemplate?.description}</p>
+                            {activeTemplate?.updated_at && (
+                              <small className="text-muted">Última actualización: {new Date(activeTemplate.updated_at).toLocaleString()}</small>
+                            )}
+                          </Col>
+                        </Row>
+                        <Form onSubmit={handleTemplateSave}>
+                          <Row className="g-3">
+                            <Col md={6}>
+                              <FormGroup>
+                                <Label>Asunto (Jinja)</Label>
+                                <Input type="textarea" rows={2} value={templateSubject} onChange={e => setTemplateSubject(e.target.value)} required />
+                              </FormGroup>
+                            </Col>
+                            <Col md={6}>
+                              <FormGroup>
+                                <Label>Contenido HTML (Jinja)</Label>
+                                <Input type="textarea" rows={8} value={templateBody} onChange={e => setTemplateBody(e.target.value)} required />
+                                <FormText className="text-muted">Variables disponibles: {(activeTemplate?.allowed_variables || []).join(', ')}</FormText>
+                              </FormGroup>
+                            </Col>
+                          </Row>
+                          <div className="d-flex gap-2 mt-3">
+                            <Button color="primary" type="submit" disabled={templateSaving}>{templateSaving ? 'Guardando…' : 'Guardar plantilla'}</Button>
+                            <Button color="secondary" type="button" onClick={handlePreviewTemplate} disabled={previewLoading}>
+                              {previewLoading ? 'Generando…' : 'Vista previa'}
+                            </Button>
+                          </div>
+                        </Form>
+                        {previewHtml && (
+                          <Card className="mt-3">
+                            <CardHeader><h6 className="mb-0">Vista previa renderizada</h6></CardHeader>
+                            <CardBody>
+                              <div className="email-preview" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+                            </CardBody>
+                          </Card>
+                        )}
+                      </>
+                    )}
+                  </CardBody>
+                </Card>
+                <Card className="mt-4">
+                  <CardHeader><h5 className="mb-0">Marca blanca</h5></CardHeader>
+                  <CardBody>
+                    <Form onSubmit={handleBrandingSave}>
+                      <Row className="g-3">
+                        <Col md={4}><Label>Nombre de marca</Label><Input value={branding.brand_name} onChange={e => setBranding(prev => ({ ...prev, brand_name: e.target.value }))} required /></Col>
+                        <Col md={4}><Label>Logo (URL)</Label><Input value={branding.logo_url || ''} onChange={e => setBranding(prev => ({ ...prev, logo_url: e.target.value }))} placeholder="https://..." /></Col>
+                        <Col md={2}><Label>Color principal</Label><Input type="text" value={branding.primary_color} onChange={e => setBranding(prev => ({ ...prev, primary_color: e.target.value }))} /></Col>
+                        <Col md={2}><Label>Color texto botón</Label><Input type="text" value={branding.button_text_color} onChange={e => setBranding(prev => ({ ...prev, button_text_color: e.target.value }))} /></Col>
+                        <Col md={12}><Label>Pie de página</Label><Input type="textarea" rows={2} value={branding.footer_text || ''} onChange={e => setBranding(prev => ({ ...prev, footer_text: e.target.value }))} placeholder="© {{ brand.brand_name }}" /></Col>
+                      </Row>
+                      <Button color="primary" type="submit" className="mt-3" disabled={brandingSaving}>{brandingSaving ? 'Guardando…' : 'Guardar marca'}</Button>
+                    </Form>
+                  </CardBody>
+                </Card>
+                <Card className="mt-4">
+                  <CardHeader><h5 className="mb-0">Webhook de eventos</h5></CardHeader>
+                  <CardBody>
+                    <Form onSubmit={handleWebhookSave}>
+                      <Row className="g-3">
+                        <Col md={6}><Label>URL destino</Label><Input type="url" value={webhook.url || ''} onChange={e => setWebhook(prev => ({ ...prev, url: e.target.value }))} placeholder="https://integracion.example.com/webhook" /></Col>
+                        <Col md={6}><Label>Secreto (opcional)</Label><Input value={webhook.secret || ''} onChange={e => setWebhook(prev => ({ ...prev, secret: e.target.value }))} placeholder="clave para firmar mensajes" /></Col>
+                      </Row>
+                      <Row className="g-3 mt-1">
+                        <Col md={3} className="mt-2">
+                          <FormGroup check>
+                            <Input id="webhook-enabled" type="checkbox" checked={webhook.enabled} onChange={e => setWebhook(prev => ({ ...prev, enabled: e.target.checked }))} />
+                            <Label check htmlFor="webhook-enabled">Webhook activo</Label>
+                          </FormGroup>
+                        </Col>
+                        <Col md={9}>
+                          <Label>Eventos enviados</Label>
+                          <div className="d-flex flex-wrap gap-3">
+                            {AVAILABLE_WEBHOOK_EVENTS.map(eventKey => (
+                              <FormGroup check className="me-3" key={eventKey}>
+                                <Input
+                                  type="checkbox"
+                                  id={`webhook-${eventKey}`}
+                                  checked={webhook.enabled_events.includes(eventKey)}
+                                  onChange={e => toggleWebhookEvent(eventKey, e.target.checked)}
+                                />
+                                <Label check htmlFor={`webhook-${eventKey}`}>{eventKey}</Label>
+                              </FormGroup>
+                            ))}
+                          </div>
+                          <FormText className="text-muted">Se enviará un POST en formato JSON con firma opcional cuando ocurran estos eventos.</FormText>
+                        </Col>
+                      </Row>
+                      <Button color="primary" type="submit" className="mt-3" disabled={webhookSaving}>{webhookSaving ? 'Guardando…' : 'Guardar webhook'}</Button>
+                    </Form>
+                  </CardBody>
+                </Card>
               </TabPane>
             </TabContent>
           </>

--- a/tests/api.http
+++ b/tests/api.http
@@ -280,12 +280,12 @@ Authorization: Bearer {{accessToken}}
 DELETE {{baseUrl}}/api/users/{user_id}
 Authorization: Bearer {{accessToken}}
 
-### Users: reenviar invitaciÃ³n si pending (si no caducÃ³, reutiliza)
-# Ajusta {user_id} de un usuario con estado pending
+# Users: reenviar invitación (limita por rate limit e idempotencia)
+# Ajusta {user_id} de un usuario con estado pending. Devuelve reused/idempotent y el enlace cuando corresponde.
 POST {{baseUrl}}/api/users/{user_id}/resend-invitation
 Authorization: Bearer {{accessToken}}
 
-### Users: reenviar invitaciÃ³n para usuario activo (debe 400)
+# Users: reenviar invitación para usuario activo (debe 400)
 POST {{baseUrl}}/api/users/{active_user_id}/resend-invitation
 Authorization: Bearer {{accessToken}}
 
@@ -307,6 +307,75 @@ Content-Type: application/json
 
 ### Users: validar invitaciÃ³n (token de ejemplo)
 GET {{baseUrl}}/api/users/invitations/validate?token=REEMPLAZA_TOKEN
+
+
+### Settings: obtener plantillas y marca blanca
+GET {{baseUrl}}/api/settings/email/templates
+Authorization: Bearer {{accessToken}}
+
+### Settings: actualizar plantilla de invitaciÃ³n
+PUT {{baseUrl}}/api/settings/email/templates/user_invitation
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "subject_template": "{{ organization_name }} te espera, {{ invitee_name }}",
+  "body_html": "<p>Hola {{ invitee_name }},</p><p>Usa el siguiente enlace: <a class=\"button\" href=\"{{ invite_link }}\">Acceder</a></p><p>Caduca el {{ expires_at }}.</p>"
+}
+
+### Settings: vista previa de la plantilla de invitaciÃ³n
+POST {{baseUrl}}/api/settings/email/templates/user_invitation/preview
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "variables": {
+    "invitee_name": "Equipo QA"
+  }
+}
+
+### Settings: actualizar marca blanca
+PATCH {{baseUrl}}/api/settings/email/templates/branding
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "brand_name": "Confianet QA",
+  "logo_url": "https://static.example.com/logo.png",
+  "primary_color": "#0f172a",
+  "button_text_color": "#ffffff",
+  "footer_text": "© {{ brand.brand_name }}"
+}
+
+### Settings: enviar email de prueba (requiere SMTP configurado)
+POST {{baseUrl}}/api/settings/email/test
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "to_email": "qa@example.com",
+  "template_id": "user_invitation"
+}
+
+### Settings: obtener webhook de eventos
+GET {{baseUrl}}/api/settings/webhooks
+Authorization: Bearer {{accessToken}}
+
+### Settings: configurar webhook de eventos
+PUT {{baseUrl}}/api/settings/webhooks
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "url": "https://integraciones.example.com/confianet/webhook",
+  "secret": "demo-secret",
+  "enabled_events": [
+    "user.invited",
+    "user.activated",
+    "user.suspended"
+  ],
+  "enabled": true
+}
 
 
 ### Rate limit: 6 intentos fallidos (espera 429)


### PR DESCRIPTION
## Summary
- add backend email template manager with branding, a test email endpoint, and webhook configuration storage
- update user invitations to use templated messages, enforce rate limiting/idempotency, store raw tokens, and trigger outbound webhooks
- expand the admin settings UI and API tests to manage templates, branding, test emails, and webhook integrations

## Testing
- npm test -- --watchAll=false *(fails: react-scripts not found)*
- python -m compileall backend/app


------
https://chatgpt.com/codex/tasks/task_b_68c9cb9cb3d4833296f1092dbe419e2a